### PR TITLE
Added ES5 compatibility without breaking constructor props

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var React = require('react')
 var ReactDOM = require('react-dom')
 
-class Component extends React.Component {}
+Component.prototype = Object.create(React.Component.prototype)
 
 function withReact (state, emitter, app) {
   app._mount = (tree, newTree) => ReactDOM.render(newTree, tree)
@@ -10,6 +10,10 @@ function withReact (state, emitter, app) {
   Component.prototype.emit = function () {
     emitter.emit.apply(emitter, arguments)
   }
+}
+
+function Component (props) {
+  React.Component.call(this, props)
 }
 
 module.exports = withReact


### PR DESCRIPTION
Reverts the changes made in #3, but still fixes the original problem of not being able to access `this.props` from `constructor` inside a new component.

Discovered while trying to get `monoapp-react` working with `parcel-bundler`. Seems like using an ES6 class inside of `monoapp-react` won't play nicely with `parcel-bundler`'s default `browserslist` settings.